### PR TITLE
Create dao.py

### DIFF
--- a/dao.py
+++ b/dao.py
@@ -1,0 +1,71 @@
+"""Data Access Object (DAO) for interacting with PostgreSQL database."""
+import logging
+from typing import Union
+
+import pandas as pd
+from asyncpg import Pool, create_pool
+from asyncpg.exceptions import PostgresError
+
+import settings
+
+logger = logging.getLogger(__name__)
+
+class PostgresDAO:
+    """Data Access Object for PostgreSQL database interactions."""
+
+    def __init__(self) -> None:
+        """Initialize the PostgresDAO with an uninitialized connection pool."""
+        self.pool: Union[Pool, None] = None
+
+    async def setup(self) -> None:
+        """Set up the PostgreSQL connection pool.
+
+        Raises:
+            RuntimeError: If the pool initialization fails due to a PostgresError.
+        """
+        try:
+            self.pool = await create_pool(
+                dsn=settings.BACKTEST_DB_URL,
+                min_size=1,
+                max_size=10,
+            )
+            logger.info("PostgresDAO pool initialized")
+        except PostgresError as e:
+            logger.exception("Failed to initialize pool")
+            raise RuntimeError(f"Database pool initialization failed: {str(e)}") from e
+
+    async def get_data(self, start_date: str, end_date: str) -> pd.DataFrame:
+        """Fetch BTC price data from the database for a given date range.
+
+        Args:
+            start_date: Start date in ISO format (e.g., '2023-01-01').
+            end_date: End date in ISO format (e.g., '2023-12-31').
+
+        Returns:
+            A pandas DataFrame containing price data or an empty DataFrame if no data is found.
+
+        Raises:
+            ValueError: If the database pool is not initialized.
+            PostgresError: If a database error occurs.
+        """
+        if not self.pool:
+            raise ValueError("Database pool not initialized")
+        query = """
+            SELECT timestamp, open, high, low, close, r_1, r_2
+            FROM btc_prices
+            WHERE timestamp >= $1 AND timestamp <= $2
+            ORDER BY timestamp
+        """
+        try:
+            async with self.pool.acquire() as conn:
+                rows = await conn.fetch(query, pd.to_datetime(start_date), pd.to_datetime(end_date))
+        except PostgresError as e:
+            logger.exception("Error fetching data")
+            return pd.DataFrame()
+        else:
+            if not rows:
+                logger.warning("No data found for %s to %s", start_date, end_date)
+                return pd.DataFrame()
+            price_data = pd.DataFrame(rows, columns=['timestamp', 'open', 'high', 'low', 'close', 'r_1', 'r_2'])
+            logger.info("Fetched %d price records", len(price_data))
+            return price_data


### PR DESCRIPTION
/review

"""Unit tests for PostgresDAO."""
import logging
from datetime import datetime
from unittest.mock import AsyncMock, MagicMock

import pandas as pd
import pytest
from asyncpg import Pool
from asyncpg.exceptions import PostgresError

from dao import PostgresDAO

@pytest.fixture
def dao():
    """Create a PostgresDAO instance for testing."""
    dao = PostgresDAO()
    dao.pool = AsyncMock(spec=Pool)
    return dao

@pytest.mark.asyncio
async def test_setup_success(monkeypatch):
    """Test successful pool initialization."""
    mock_create_pool = AsyncMock(return_value=MagicMock(spec=Pool))
    monkeypatch.setattr("dao.create_pool", mock_create_pool)

    dao = PostgresDAO()
    await dao.setup()

    assert dao.pool is not None
    mock_create_pool.assert_awaited_once()

@pytest.mark.asyncio
async def test_setup_failure(monkeypatch):
    """Test pool initialization failure."""
    mock_create_pool = AsyncMock(side_effect=PostgresError("Connection failed"))
    monkeypatch.setattr("dao.create_pool", mock_create_pool)

    dao = PostgresDAO()
    with pytest.raises(RuntimeError, match="Database pool initialization failed"):
        await dao.setup()

@pytest.mark.asyncio
async def test_get_data_success(dao):
    """Test successful data retrieval."""
    mock_conn = AsyncMock()
    mock_conn.fetch = AsyncMock(
        return_value=[
            {"timestamp": datetime(2023, 1, 1), "open": 100, "high": 110, "low": 90, "close": 105, "r_1": 1.0, "r_2": 2.0}
        ]
    )
    dao.pool.acquire = AsyncMock(return_value=mock_conn)

    result = await dao.get_data("2023-01-01", "2023-01-02")

    assert isinstance(result, pd.DataFrame)
    assert len(result) == 1
    assert list(result.columns) == ["timestamp", "open", "high", "low", "close", "r_1", "r_2"]
    mock_conn.fetch.assert_awaited_once()

@pytest.mark.asyncio
async def test_get_data_no_pool(dao):
    """Test get_data when pool is not initialized."""
    dao.pool = None
    with pytest.raises(ValueError, match="Database pool not initialized"):
        await dao.get_data("2023-01-01", "2023-01-02")

@pytest.mark.asyncio
async def test_get_data_no_data(dao):
    """Test get_data when no data is found."""
    mock_conn = AsyncMock()
    mock_conn.fetch = AsyncMock(return_value=[])
    dao.pool.acquire = AsyncMock(return_value=mock_conn)

    result = await dao.get_data("2023-01-01", "2023-01-02")

    assert isinstance(result, pd.DataFrame)
    assert result.empty
    mock_conn.fetch.assert_awaited_once()

@pytest.mark.asyncio
async def test_get_data_postgres_error(dao, caplog):
    """Test get_data when a PostgresError occurs."""
    mock_conn = AsyncMock()
    mock_conn.fetch = AsyncMock(side_effect=PostgresError("Query failed"))
    dao.pool.acquire = AsyncMock(return_value=mock_conn)

    with caplog.at_level(logging.ERROR):
        result = await dao.get_data("2023-01-01", "2023-01-02")

    assert isinstance(result, pd.DataFrame)
    assert result.empty
    assert "Error fetching data" in caplog.text
    mock_conn.fetch.assert_awaited_once()

if __name__ == "__main__":
    pytest.main(["-v"]) 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR implements a new PostgreSQL data access layer with async operations and connection pooling. It provides methods for querying BTC price data with robust error handling. The changes include comprehensive documentation and logging for better traceability, enhancing overall database interaction reliability.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>